### PR TITLE
make only unique node names

### DIFF
--- a/Runtime/Scripts/GLTFSceneExporter.cs
+++ b/Runtime/Scripts/GLTFSceneExporter.cs
@@ -1024,7 +1024,7 @@ namespace UnityGLTF
 
 			if (ExportNames)
 			{
-				node.Name = nodeTransform.name;
+				node.Name = nodeTransform.name + _root.Nodes.Count;
 			}
 			
 			// TODO think more about how this callback is used – could e.g. be modifying the hierarchy,

--- a/Runtime/Scripts/GLTFSceneExporter.cs
+++ b/Runtime/Scripts/GLTFSceneExporter.cs
@@ -1013,6 +1013,14 @@ namespace UnityGLTF
 			};
 		}
 
+		private string makeUniqueNodeName(Transform nodeTransform) 
+		{
+			if (_root.Nodes.Exists(n => n.Name == nodeTransform.name))
+				return nodeTransform.name + _root.Nodes.Count;
+			else
+				return nodeTransform.name;
+		}
+		
 		private NodeId ExportNode(Transform nodeTransform)
 		{
 			if (_exportedTransforms.TryGetValue(nodeTransform.GetInstanceID(), out var existingNodeId))
@@ -1024,7 +1032,7 @@ namespace UnityGLTF
 
 			if (ExportNames)
 			{
-				node.Name = nodeTransform.name + _root.Nodes.Count;
+				node.Name = makeUniqueNodeName(nodeTransform);
 			}
 			
 			// TODO think more about how this callback is used – could e.g. be modifying the hierarchy,


### PR DESCRIPTION
There is an issue, where some gameObjects of an imported .glb cannot get animated when they are named the same. This PR fixes this issue via naming all nodes always uniquely.

_Not sure if it is okay when nodes may often have a bunch of digits after their original name (like after this change), but this fixes the issue just very straightforwardly._