### PR TITLE
6325 Make imported aerial images transparent

### DIFF
--- a/Runtime/Plugins/GLTFSerialization/Schema/GLTFMaterial.cs
+++ b/Runtime/Plugins/GLTFSerialization/Schema/GLTFMaterial.cs
@@ -175,7 +175,7 @@ namespace GLTF.Schema
 
 			if (material.Extras is JObject extras && 
 				extras.ContainsKey("shaderName") && 
-				extras["shaderName"] is JValue shaderName) {
+				extras["shaderName"] is JValue { Type: JTokenType.String } shaderName) {
 				material.OriginalUnityShaderName = shaderName.Value<string>();
 			}
 

--- a/Runtime/Plugins/GLTFSerialization/Schema/GLTFMaterial.cs
+++ b/Runtime/Plugins/GLTFSerialization/Schema/GLTFMaterial.cs
@@ -173,9 +173,9 @@ namespace GLTF.Schema
 				}
 			}
 
-			if (material.Extras is not null && 
-				material.Extras.Contains("shaderName") && 
-				material.Extras["shaderName"] is JValue shaderName) {
+			if (material.Extras is JObject extras && 
+				extras.ContainsKey("shaderName") && 
+				extras["shaderName"] is JValue shaderName) {
 				material.OriginalUnityShaderName = shaderName.Value<string>();
 			}
 


### PR DESCRIPTION
Fix material import issue where OriginalUnityShaderName could never be found and every imported material wrongfully used the default shader