### PR TITLE
Write out stream on thread

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -221,3 +221,6 @@ sysinfo.txt
 
 .idea
 UnityGLTF/Logs/
+UnityGLTF/Logs.meta
+UnityGLTF/obj.meta
+UnityGLTF/UnityGLTF.sln.meta

--- a/Runtime/Scripts/SceneExporter/ExporterAccessors.cs
+++ b/Runtime/Scripts/SceneExporter/ExporterAccessors.cs
@@ -18,24 +18,6 @@ public partial class GLTFSceneExporter
 #endif
 
 	/// <summary>
-	/// Convenience function to copy from a stream to a binary writer, for
-	/// compatibility with pre-.NET 4.0.
-	/// Note: Does not set position/seek in either stream. After executing,
-	/// the input buffer's position should be the end of the stream.
-	/// </summary>
-	/// <param name="input">Stream to copy from</param>
-	/// <param name="output">Stream to copy to.</param>
-	private static void CopyStream(Stream input, BinaryWriter output)
-	{
-		byte[] buffer = new byte[8 * 1024];
-		int length;
-		while ((length = input.Read(buffer, 0, buffer.Length)) > 0)
-		{
-			output.Write(buffer, 0, length);
-		}
-	}
-
-	/// <summary>
 	/// Pads a stream with additional bytes.
 	/// </summary>
 	/// <param name="stream">The stream to be modified.</param>

--- a/UnityGLTF/Packages.meta
+++ b/UnityGLTF/Packages.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b32278c6728379f4898b85727b0f1a63
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Splits GltfSceneExporter SaveGLBToStream into multiple smaller methods and adds an overload that writes the files to disk on a background thread that is awaitable. This is much faster.


Also replaces the custom method `CopyStream(Stream, BinaryWriter)` with `Stream.CopyTo`, which is available since c# 4.0 (Unity 2018, maybe even older), and seems to be much faster
