### PR TITLE
Export fixes

### DIFF
--- a/Runtime/Scripts/Timeline/Internal/Samplers/BaseColorSampler.cs
+++ b/Runtime/Scripts/Timeline/Internal/Samplers/BaseColorSampler.cs
@@ -11,12 +11,15 @@ namespace UnityGLTF.Timeline.Samplers
 
         public override IEqualityComparer<Color?> DataComparer => EqualityComparer<Color?>.Default;
 
-        internal override Material getTarget(Transform transform) =>
-            transform.TryGetComponent<MeshRenderer>(out var mr)
-                ? mr.sharedMaterial
-                : transform.TryGetComponent<SkinnedMeshRenderer>(out var smr)
-                    ? smr.sharedMaterial
-                    : null;
+        internal override Material getTarget(Transform transform) {
+            if (!transform) 
+                return null;
+            if (transform.TryGetComponent<MeshRenderer>(out var mr)) 
+                return mr.sharedMaterial;
+            if (transform.TryGetComponent<SkinnedMeshRenderer>(out var smr))
+                return smr.sharedMaterial;
+            return null;
+        }
 
         public override Color? GetValue(Transform transform, Material target, AnimationData data) {
             

--- a/Runtime/Scripts/Timeline/Internal/Samplers/BlendWeightSampler.cs
+++ b/Runtime/Scripts/Timeline/Internal/Samplers/BlendWeightSampler.cs
@@ -11,7 +11,11 @@ namespace UnityGLTF.Timeline.Samplers
 
         public override IEqualityComparer<float[]> DataComparer => EqualityComparer<float[]>.Default;
         
-        internal override SkinnedMeshRenderer getTarget(Transform transform) => transform.TryGetComponent<SkinnedMeshRenderer>(out var smr) ? smr : null;
+        internal override SkinnedMeshRenderer getTarget(Transform transform) {
+            if (!transform) 
+                return null;
+            return transform.TryGetComponent<SkinnedMeshRenderer>(out var smr) ? smr : null;
+        }
 
         public override float[] GetValue(Transform transform, SkinnedMeshRenderer target, AnimationData data) {
             if (target.sharedMesh) {

--- a/Runtime/Scripts/Timeline/Internal/Samplers/VisibilitySampler.cs
+++ b/Runtime/Scripts/Timeline/Internal/Samplers/VisibilitySampler.cs
@@ -18,7 +18,11 @@ namespace UnityGLTF.Timeline.Samplers
         internal VisibilityTrack startNewAnimationTrackAtStartOfTime(AnimationData data, float time) =>
             new VisibilityTrack(data, this, time);
 
-        internal override GameObject getTarget(Transform transform) => transform.gameObject;
+        internal override GameObject getTarget(Transform transform) {
+            if (!transform) 
+                return null;
+            return transform.gameObject;
+        }
 
         public override bool GetValue(Transform transform, GameObject target, AnimationData data) =>
             target.activeSelf;


### PR DESCRIPTION
Fixes potential null exceptions in the samplers & adds a new export method that allows to use custom streams for static & json data of an export. This allows to circumvent the 2gb maximum size of MemoryStream