### PR TITLE
export file size as 4-byte value again

### DIFF
--- a/Runtime/Scripts/GLTFSceneExporter.cs
+++ b/Runtime/Scripts/GLTFSceneExporter.cs
@@ -835,7 +835,7 @@ namespace UnityGLTF
 			// write header
 			writer.Write(MagicGLTF);
 			writer.Write(Version);
-			writer.Write(glbLength);
+			writer.Write((int)glbLength);
 
 			gltfWriteJsonStreamMarker.Begin();
 			// write JSON chunk header.


### PR DESCRIPTION
fix oopsie that caused invalid alignment in the file